### PR TITLE
Language for TextField support

### DIFF
--- a/Sources/FocusOnAppear/Configuration.swift
+++ b/Sources/FocusOnAppear/Configuration.swift
@@ -9,12 +9,15 @@ public struct Configuration {
     public let returnKeyType: ReturnKeyType
     /// A Boolean value that indicates whether the input field is `SecureField`.
     public let isSecure: Bool
+    /// Configure the language of the keyboard
+    public let languageCode: String?
 
     /// Initialize `Configuration` with the given parameters.
-    public init(keyboardType: KeyboardType = .default, returnKeyType: ReturnKeyType = .default, isSecure: Bool = false) {
+    public init(keyboardType: KeyboardType = .default, returnKeyType: ReturnKeyType = .default, isSecure: Bool = false, languageCode: String? = nil) {
         self.keyboardType = keyboardType
         self.returnKeyType = returnKeyType
         self.isSecure = isSecure
+        self.languageCode = languageCode
     }
 
     /// The default configuration for `focusOnAppear`.

--- a/Sources/FocusOnAppear/FirstResponderFieldView.swift
+++ b/Sources/FocusOnAppear/FirstResponderFieldView.swift
@@ -4,18 +4,35 @@ import SwiftUI
 #if os(iOS)
 
 class FirstResponderField: UITextField {
+    var languageCode: String?
 
     init(_ config: Configuration) {
         super.init(frame: .zero)
         keyboardType = config.keyboardType
         returnKeyType = config.returnKeyType
         isSecureTextEntry = config.isSecure
+        languageCode = config.languageCode
         becomeFirstResponder()
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    override var textInputMode: UITextInputMode? {
+        if let languageCode = languageCode {
+            for inputMode in UITextInputMode.activeInputModes {
+                if let inputModeLanguage = inputMode.primaryLanguage {
+                    let locale = Locale(identifier: inputModeLanguage)
+                    if locale.languageCode == languageCode {
+                        return inputMode
+                    }
+                }
+            }
+        }
+        return super.textInputMode
+    }
+    
 }
 
 struct FirstResponderFieldView: UIViewRepresentable {


### PR DESCRIPTION
Hi! Thank you for your library. I've added your solution to my project but in my app I set a locale for the keyboard when focusing TextField. In my case a standard keyboard opens at first (with default language, from your library) and then is replaced by another keyboard (with selected language), it leads to a strange behavior when the language of the keyboard is changed right in front of the user. Because of that, I've decided to add language support to your library. Thanks!